### PR TITLE
Fix MPS backward crash

### DIFF
--- a/network/model.py
+++ b/network/model.py
@@ -214,7 +214,7 @@ class ContrastDrivenFeatureAggregation(nn.Module):
 
         B, H, W, C = x.shape
 
-        v = self.v(x).permute(0, 3, 1, 2)
+        v = self.v(x).permute(0, 3, 1, 2).contiguous()
 
         v_unfolded = self.unfold(v).reshape(B, self.num_heads, self.head_dim,
                                             self.kernel_size * self.kernel_size,
@@ -223,7 +223,7 @@ class ContrastDrivenFeatureAggregation(nn.Module):
 
         x_weighted_fg = self.apply_attention(attn_fg, v_unfolded, B, H, W, C)
 
-        v_unfolded_bg = self.unfold(x_weighted_fg.permute(0, 3, 1, 2)).reshape(B, self.num_heads, self.head_dim,
+        v_unfolded_bg = self.unfold(x_weighted_fg.permute(0, 3, 1, 2).contiguous()).reshape(B, self.num_heads, self.head_dim,
                                                                                self.kernel_size * self.kernel_size,
                                                                                -1).permute(0, 1, 4, 3, 2)
         attn_bg = self.compute_attention(bg, B, H, W, C, 'bg')
@@ -241,7 +241,7 @@ class ContrastDrivenFeatureAggregation(nn.Module):
         attn_layer = self.attn_fg if feature_type == 'fg' else self.attn_bg
         h, w = math.ceil(H / self.stride), math.ceil(W / self.stride)
 
-        feature_map_pooled = self.pool(feature_map.permute(0, 3, 1, 2)).permute(0, 2, 3, 1)
+        feature_map_pooled = self.pool(feature_map.permute(0, 3, 1, 2).contiguous()).permute(0, 2, 3, 1)
 
         attn = attn_layer(feature_map_pooled).reshape(B, h * w, self.num_heads,
                                                       self.kernel_size * self.kernel_size,

--- a/network_pvt/pvt.py
+++ b/network_pvt/pvt.py
@@ -93,7 +93,7 @@ class SAM(nn.Module):
         n, c, h, w = x.size()
         edge = torch.nn.functional.softmax(edge, dim=1)[:, 1, :, :].unsqueeze(1)
 
-        x_state_reshaped = self.conv_state(x).view(n, self.num_s, -1)
+        x_state_reshaped = self.conv_state(x).reshape(n, self.num_s, -1)
         x_proj = self.conv_proj(x)
         x_mask = x_proj * edge
 
@@ -112,7 +112,7 @@ class SAM(nn.Module):
         x_n_rel = self.gcn(x_n_state)
 
         x_state_reshaped = torch.matmul(x_n_rel, x_rproj_reshaped)
-        x_state = x_state_reshaped.view(n, self.num_s, *x.size()[2:])
+        x_state = x_state_reshaped.reshape(n, self.num_s, *x.size()[2:])
         out = x + (self.conv_extend(x_state))
 
         return out

--- a/network_pvt/pvtv2.py
+++ b/network_pvt/pvtv2.py
@@ -366,7 +366,7 @@ class DWConv(nn.Module):
 
     def forward(self, x, H, W):
         B, N, C = x.shape
-        x = x.transpose(1, 2).view(B, C, H, W)
+        x = x.transpose(1, 2).reshape(B, C, H, W)
         x = self.dwconv(x)
         x = x.flatten(2).transpose(1, 2)
 

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -117,8 +117,8 @@ class DiceLoss(nn.Module):
     def forward(self, inputs, targets, smooth=1):
         inputs = torch.sigmoid(inputs)
 
-        inputs = inputs.view(-1)
-        targets = targets.view(-1)
+        inputs = inputs.reshape(-1)
+        targets = targets.reshape(-1)
 
         intersection = (inputs * targets).sum()
         dice = (2.*intersection + smooth)/(inputs.sum() + targets.sum() + smooth)
@@ -132,8 +132,8 @@ class DiceBCELoss(nn.Module):
     def forward(self, inputs, targets, smooth=1):
         inputs = torch.sigmoid(inputs)
 
-        inputs = inputs.view(-1)
-        targets = targets.view(-1)
+        inputs = inputs.reshape(-1)
+        targets = targets.reshape(-1)
 
         intersection = (inputs * targets).sum()
         dice_loss = 1 - (2.*intersection + smooth)/(inputs.sum() + targets.sum() + smooth)


### PR DESCRIPTION
## Summary
- keep tensors contiguous before unfolding operations

## Testing
- `python train.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6857f93957fc83329645eb2b2f65c437