### PR TITLE
Handle fold failures gracefully

### DIFF
--- a/network_pvt/model.py
+++ b/network_pvt/model.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -276,8 +277,18 @@ class ContrastDrivenFeatureAggregation(nn.Module):
                                  kernel_size=self.kernel_size,
                                  padding=self.padding, stride=self.stride)
         else:
-            x_weighted = F.fold(x_weighted, output_size=(H, W), kernel_size=self.kernel_size,
-                                padding=self.padding, stride=self.stride)
+            try:
+                x_weighted = F.fold(x_weighted, output_size=(H, W),
+                                    kernel_size=self.kernel_size,
+                                    padding=self.padding, stride=self.stride)
+            except RuntimeError:
+                warnings.warn(
+                    "F.fold failed on device {}. Falling back to CPU. This may be slower.".format(x_weighted.device),
+                    RuntimeWarning,
+                )
+                x_weighted = F.fold(x_weighted.cpu(), output_size=(H, W),
+                                    kernel_size=self.kernel_size,
+                                    padding=self.padding, stride=self.stride).to(attn.device)
         x_weighted = self.proj(x_weighted.permute(0, 2, 3, 1))
         x_weighted = self.proj_drop(x_weighted)
         return x_weighted


### PR DESCRIPTION
## Summary
- make `apply_attention` robust to `F.fold` failures
- fall back to CPU and warn when fold fails

## Testing
- `python -m py_compile network/model.py network_pvt/model.py`
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580e9329e88332aaf67ea3546e2d8e